### PR TITLE
Fix broken anchor links in Firefox on speaker page

### DIFF
--- a/source/stylesheets/components/_speakers.sass
+++ b/source/stylesheets/components/_speakers.sass
@@ -2,6 +2,8 @@
   background: $white
   display: block
 
+.speakers-page--item
+  display: inline-block
 
 .speakers--container
   @extend %container


### PR DESCRIPTION
This fixes https://github.com/eurucamp/2014.eurucamp.org/issues/55
