### PR TITLE
Lower z-index of section titles in the sponsors section

### DIFF
--- a/source/stylesheets/components/_sponsors.sass
+++ b/source/stylesheets/components/_sponsors.sass
@@ -93,6 +93,7 @@
   .sponsors--section-title
     @extend %page--section-title
     color: $white
+    z-index: -1
     margin-top: 200px
     margin-left: 200px
     margin-bottom: -200px


### PR DESCRIPTION
Otherwise the titles will overlap the sponsor logos.
refs eurucamp/2014.eurucamp.org#81

![screenshot from 2014-07-26 07 58 00](https://cloud.githubusercontent.com/assets/51264/3710428/21702a64-148b-11e4-8080-96e174a41102.png)
