### PR TITLE
Set maximum width for inline images.

### DIFF
--- a/source/2015/components/_text.lsg
+++ b/source/2015/components/_text.lsg
@@ -23,5 +23,8 @@ Text
     * List item
     * Another list item
     * Last list item
-```
 
+    ![Content image](images/grass.jpg)
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+```

--- a/source/2015/components/_text.sass
+++ b/source/2015/components/_text.sass
@@ -78,3 +78,5 @@
       position: absolute
       right: 102%
 
+  img
+    max-width: 100%


### PR DESCRIPTION
The blog http://blog.eurucamp.org/2014/08/08/favourite-moments/ contains images that flow out of the text border.
