### PR TITLE
Add sponsoring css from 2014

### DIFF
--- a/source/2015/base/_colors.sass
+++ b/source/2015/base/_colors.sass
@@ -11,3 +11,11 @@ $gray: #cbdbda
 $dark-gray: #2f4644
 $black: #212c2b
 
+
+$fuchsia: #FF006A
+$red: #CC2301
+$dark-red: #991A00
+
+$light-green: #B1FF91
+$green: #7BCB5A
+

--- a/source/2015/components/_sponsor.sass
+++ b/source/2015/components/_sponsor.sass
@@ -254,6 +254,7 @@ body
 .my-sponsors-page--info-text
   @extend %pie-clearfix
   @include grid(6, 4, 4)
+  color: white
   margin-left: 33%
   margin-top: 100px
   font-size: 1.5rem

--- a/source/2015/components/_sponsor.sass
+++ b/source/2015/components/_sponsor.sass
@@ -17,3 +17,259 @@
 .sponsor--image
   height: auto
   width: 100%
+
+body
+  background: #913BBE
+
+.my-sponsors
+  display: block
+
+
+.my-sponsors--container
+  @extend %container
+  padding-bottom: 0px
+  margin-bottom: 0px
+
+
+.my-sponsors--title
+  @extend %headline
+
+  &:before
+    content: inline-svg("sponsors--icon.svg")
+    display: block
+    margin: auto
+    width: 20px
+
+
+.my-sponsors--section-title
+  @extend %pie-clearfix
+  font-size: 1.5rem
+  text-transform: uppercase
+  @include grid(12, 8, 6)
+  text-align: center
+  font-weight: bold
+  color: $red
+  padding-bottom: 50px
+
+.my-sponsors--list
+  display: block
+  margin-top: 100px
+  @media all and (max-width: 800px)
+    margin-top: 100px
+
+.my-sponsors--list-item-label, .my-sponsors--page-list-item-label
+  display: block
+  background: $red
+  color: $white
+  opacity: 1
+  text-align: right
+  padding-right: 1%
+  padding-top: 3px
+  margin: -1% 65% 0 130%
+  margin-top: -0%
+  margin-left: -20%
+  font-weight: bold
+  text-transform: uppercase
+  @include transform(rotate(-90deg))
+
+.my-sponsors--list-item-label
+  margin: -1% 70% 0 70%
+  margin-top: -30%
+  margin-left: -20%
+
+.-nickel
+  .my-sponsors--page-list-item-label
+    margin-top: -30%
+
+.my-sponsors--list-item
+  @include grid(4, 4, 6)
+  margin-top: 0px
+  margin-bottom: 50px
+  height: 200px
+  max-width: 350px
+
+
+.my-sponsors--list-item-image
+  padding: 0 20px 0 20px
+  display: inline-block
+  width: 100%
+
+.my-sponsors--buttons
+  @extend %pie-clearfix
+
+
+.my-sponsors--show-more
+  @extend %show-more
+  background: $dark-red
+  &:hover
+    background: $red
+
+.my-sponsors.-home
+  padding-bottom: 50px
+
+
+.my-sponsors-page--title
+  @extend %page--title
+  font-size: 6rem
+  margin: 170px
+  @include transform-origin(100px, 250px)
+  @media all and (max-width: 600px)
+    font-size: 4rem
+    @include transform-origin(150px, 150px)
+    margin: 40px
+
+.my-sponsors-page--companies
+  .my-sponsors--section
+    @extend %page--section
+
+  .my-sponsors--section-title
+    @extend %page--section-title
+    color: $white
+    z-index: -1
+    margin-top: 200px
+    margin-left: 200px
+    margin-bottom: -200px
+    &:before
+      background: $white
+    @media all and (max-width: 800px)
+      color: $black
+      margin-top: 100px
+      margin-left: 0px
+      text-align: left
+      margin-bottom: -50px
+  .my-sponsors--list
+    @extend %pie-clearfix
+
+  .my-sponsors--section.-gold
+    .my-sponsors--section-title:before
+      background: #c4af70
+    .my-sponsors--section-title
+      @media all and (max-width: 800px)
+        margin-top: 300px
+        margin-bottom: 10px
+      @media all and (max-width: 600px)
+        margin-top: 150px
+
+    .my-sponsors--list-item
+      @include grid(12, 8, 6)
+      height: 100%
+      max-width: 100%
+      margin-top: 100px
+      margin-bottom: 0
+      padding-bottom: 100px
+      img
+        max-height: 100%
+        padding: 0 10% 0 10%
+      @media all and (max-width: 800px)
+        margin-top: 100px
+        margin-bottom: 0
+    .my-sponsors--list-item-name
+      @include grid(8, 4, 6)
+    .my-sponsors--section-item-text
+      color: white
+      @include grid(4, 4, 6)
+      @media all and (max-width: 600px)
+        padding: 30px 10% 30px 10%
+        font-size: 18px
+
+  .my-sponsors--section.-silver
+    margin-top: -100px
+    .my-sponsors--section-title:before
+      background: $gray
+    .my-sponsors--section-title
+      @media all and (max-width: 800px)
+        margin-top: 300px
+        margin-bottom: 10px
+      @media all and (max-width: 600px)
+        margin-top: 150px
+
+    .my-sponsors--list-item
+      @include grid(12, 8, 6)
+      height: 100%
+      max-width: 100%
+      margin-top: 100px
+      margin-bottom: 0
+      img
+        max-height: 100%
+        padding: 0 10% 0 10%
+      @media all and (max-width: 800px)
+        margin-top: 100px
+        margin-bottom: 0
+    .my-sponsors--list-item-name
+      @include grid(6, 4, 6)
+    .my-sponsors--section-item-text
+      @include grid(6, 4, 6)
+      @media all and (max-width: 600px)
+        padding: 30px 10% 30px 10%
+        font-size: 18px
+
+  .my-sponsors--section.-nickel
+    margin-top: 150px
+    margin-bottom: 100px
+    .my-sponsors--section-title:before
+      background: #c49570
+    .my-sponsors--section-title
+      @media all and (max-width: 800px)
+        margin-bottom: 10px
+    .my-sponsors--list
+      @include grid(12, 8, 6)
+    .my-sponsors--list-item
+      @include grid(4, 4, 6)
+      height: 150px
+      margin-top: 25px
+      @media all and (max-width: 800px)
+        margin-top: 25px
+        margin-bottom: 0
+    .my-sponsors--list-item-name
+      //@include grid(12, 8, 6)
+    .my-sponsors--section-item-text
+      display: none
+
+.my-sponsors--section-item-text
+  font-size: 17px
+  a
+    color: $red
+
+
+.my-sponsors-page--info
+  .my-sponsors--section
+    @extend %page--section
+  .my-sponsors--section-title
+    @extend %page--section-title
+    color: $white
+    margin-top: 200px
+    margin-left: 200px
+    margin-bottom: -200px
+    &:before
+      background: $fuchsia
+    @media all and (max-width: 800px)
+      color: $black
+      margin-top: 100px
+      margin-left: 0px
+      text-align: left
+      margin-bottom: 50px
+    @media all and (max-width: 600px)
+      margin-bottom: -50px
+
+.my-sponsors-page--info-text
+  @extend %pie-clearfix
+  @include grid(6, 4, 4)
+  margin-left: 33%
+  margin-top: 100px
+  font-size: 1.5rem
+  @media all and (max-width: 800px)
+    margin-top: 150px
+    margin-left: 10%
+
+.my-sponsors-page--buttons
+  @extend %pie-clearfix
+  @include grid(6, 4, 6)
+  margin-top: 50px
+  text-align: center
+
+.my-sponsors-page--show-more
+  @extend %show-more
+  background: $dark-red
+  &:hover
+    background: $red
+

--- a/source/2015/components/_sponsor.sass
+++ b/source/2015/components/_sponsor.sass
@@ -21,17 +21,17 @@
 body
   background: #913BBE
 
-.my-sponsors
+.sponsors-detail
   display: block
 
 
-.my-sponsors--container
+.sponsors-detail--container
   @extend %container
   padding-bottom: 0px
   margin-bottom: 0px
 
 
-.my-sponsors--title
+.sponsors-detail--title
   @extend %headline
 
   &:before
@@ -41,7 +41,7 @@ body
     width: 20px
 
 
-.my-sponsors--section-title
+.sponsors-detail--section-title
   @extend %pie-clearfix
   font-size: 1.5rem
   text-transform: uppercase
@@ -51,13 +51,13 @@ body
   color: $red
   padding-bottom: 50px
 
-.my-sponsors--list
+.sponsors-detail--list
   display: block
   margin-top: 100px
   @media all and (max-width: 800px)
     margin-top: 100px
 
-.my-sponsors--list-item-label, .my-sponsors--page-list-item-label
+.sponsors-detail--list-item-label, .sponsors-detail--page-list-item-label
   display: block
   background: $red
   color: $white
@@ -72,16 +72,16 @@ body
   text-transform: uppercase
   @include transform(rotate(-90deg))
 
-.my-sponsors--list-item-label
+.sponsors-detail--list-item-label
   margin: -1% 70% 0 70%
   margin-top: -30%
   margin-left: -20%
 
 .-nickel
-  .my-sponsors--page-list-item-label
+  .sponsors-detail--page-list-item-label
     margin-top: -30%
 
-.my-sponsors--list-item
+.sponsors-detail--list-item
   @include grid(4, 4, 6)
   margin-top: 0px
   margin-bottom: 50px
@@ -89,40 +89,41 @@ body
   max-width: 350px
 
 
-.my-sponsors--list-item-image
+.sponsors-detail--list-item-image
   padding: 0 20px 0 20px
   display: inline-block
   width: 100%
 
-.my-sponsors--buttons
+.sponsors-detail--buttons
   @extend %pie-clearfix
 
 
-.my-sponsors--show-more
+.sponsors-detail--show-more
   @extend %show-more
   background: $dark-red
   &:hover
     background: $red
 
-.my-sponsors.-home
+.sponsors-detail.-home
   padding-bottom: 50px
 
 
-.my-sponsors-page--title
+.sponsors-detail-page--title
   @extend %page--title
   font-size: 6rem
   margin: 170px
+  color: white
   @include transform-origin(100px, 250px)
   @media all and (max-width: 600px)
     font-size: 4rem
     @include transform-origin(150px, 150px)
     margin: 40px
 
-.my-sponsors-page--companies
-  .my-sponsors--section
+.sponsors-detail-page--companies
+  .sponsors-detail--section
     @extend %page--section
 
-  .my-sponsors--section-title
+  .sponsors-detail--section-title
     @extend %page--section-title
     color: $white
     z-index: -1
@@ -137,20 +138,20 @@ body
       margin-left: 0px
       text-align: left
       margin-bottom: -50px
-  .my-sponsors--list
+  .sponsors-detail--list
     @extend %pie-clearfix
 
-  .my-sponsors--section.-gold
-    .my-sponsors--section-title:before
+  .sponsors-detail--section.-gold
+    .sponsors-detail--section-title:before
       background: #c4af70
-    .my-sponsors--section-title
+    .sponsors-detail--section-title
       @media all and (max-width: 800px)
         margin-top: 300px
         margin-bottom: 10px
       @media all and (max-width: 600px)
         margin-top: 150px
 
-    .my-sponsors--list-item
+    .sponsors-detail--list-item
       @include grid(12, 8, 6)
       height: 100%
       max-width: 100%
@@ -163,27 +164,27 @@ body
       @media all and (max-width: 800px)
         margin-top: 100px
         margin-bottom: 0
-    .my-sponsors--list-item-name
+    .sponsors-detail--list-item-name
       @include grid(8, 4, 6)
-    .my-sponsors--section-item-text
+    .sponsors-detail--section-item-text
       color: white
       @include grid(4, 4, 6)
       @media all and (max-width: 600px)
         padding: 30px 10% 30px 10%
         font-size: 18px
 
-  .my-sponsors--section.-silver
+  .sponsors-detail--section.-silver
     margin-top: -100px
-    .my-sponsors--section-title:before
+    .sponsors-detail--section-title:before
       background: $gray
-    .my-sponsors--section-title
+    .sponsors-detail--section-title
       @media all and (max-width: 800px)
         margin-top: 300px
         margin-bottom: 10px
       @media all and (max-width: 600px)
         margin-top: 150px
 
-    .my-sponsors--list-item
+    .sponsors-detail--list-item
       @include grid(12, 8, 6)
       height: 100%
       max-width: 100%
@@ -195,46 +196,46 @@ body
       @media all and (max-width: 800px)
         margin-top: 100px
         margin-bottom: 0
-    .my-sponsors--list-item-name
+    .sponsors-detail--list-item-name
       @include grid(6, 4, 6)
-    .my-sponsors--section-item-text
+    .sponsors-detail--section-item-text
       @include grid(6, 4, 6)
       @media all and (max-width: 600px)
         padding: 30px 10% 30px 10%
         font-size: 18px
 
-  .my-sponsors--section.-nickel
+  .sponsors-detail--section.-nickel
     margin-top: 150px
     margin-bottom: 100px
-    .my-sponsors--section-title:before
+    .sponsors-detail--section-title:before
       background: #c49570
-    .my-sponsors--section-title
+    .sponsors-detail--section-title
       @media all and (max-width: 800px)
         margin-bottom: 10px
-    .my-sponsors--list
+    .sponsors-detail--list
       @include grid(12, 8, 6)
-    .my-sponsors--list-item
+    .sponsors-detail--list-item
       @include grid(4, 4, 6)
       height: 150px
       margin-top: 25px
       @media all and (max-width: 800px)
         margin-top: 25px
         margin-bottom: 0
-    .my-sponsors--list-item-name
+    .sponsors-detail--list-item-name
       //@include grid(12, 8, 6)
-    .my-sponsors--section-item-text
+    .sponsors-detail--section-item-text
       display: none
 
-.my-sponsors--section-item-text
+.sponsors-detail--section-item-text
   font-size: 17px
   a
     color: $red
 
 
-.my-sponsors-page--info
-  .my-sponsors--section
+.sponsors-detail-page--info
+  .sponsors-detail--section
     @extend %page--section
-  .my-sponsors--section-title
+  .sponsors-detail--section-title
     @extend %page--section-title
     color: $white
     margin-top: 200px
@@ -251,7 +252,7 @@ body
     @media all and (max-width: 600px)
       margin-bottom: -50px
 
-.my-sponsors-page--info-text
+.sponsors-detail-page--info-text
   @extend %pie-clearfix
   @include grid(6, 4, 4)
   color: white
@@ -262,13 +263,13 @@ body
     margin-top: 150px
     margin-left: 10%
 
-.my-sponsors-page--buttons
+.sponsors-detail-page--buttons
   @extend %pie-clearfix
   @include grid(6, 4, 6)
   margin-top: 50px
   text-align: center
 
-.my-sponsors-page--show-more
+.sponsors-detail-page--show-more
   @extend %show-more
   background: $dark-red
   &:hover

--- a/source/2015/eurucamp.css.sass
+++ b/source/2015/eurucamp.css.sass
@@ -1,4 +1,5 @@
 @import "quotation-marks"
+@import "compass"
 
 @import "base/logo"
 @import "base/reset"

--- a/source/2015/images/sponsors--icon.svg
+++ b/source/2015/images/sponsors--icon.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="270px" height="296px" viewBox="0 0 270 296" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.0.2 (7799) - http://www.bohemiancoding.com/sketch -->
+    <title>Group</title>
+    <description>Created with Sketch.</description>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="Group" sketch:type="MSLayerGroup">
+            <rect id="Rectangle-path" fill="#FFFFFF" sketch:type="MSShapeGroup" x="10.5586592" y="26.0076923" width="15.4608939" height="269.876923"></rect>
+            <ellipse id="Oval" fill="#FFFFFF" sketch:type="MSShapeGroup" cx="16.7807263" cy="16.7730769" rx="16.7807263" ry="16.7730769"></ellipse>
+            <path d="M270,160.244219 L23.0027933,184.692308 C23.0027933,184.692308 38.3632376,141.946067 38.3632376,105.318386 C38.3632376,68.690705 23.0027933,30.5307692 23.0027933,30.5307692 L270,54.9736279 L202.439278,106.081899 L270,160.244219 L270,160.244219 Z" id="Shape" fill="#991A00" sketch:type="MSShapeGroup"></path>
+            <path d="M53.1703911,33.1692308 L196.468717,167.730769 L270,160.412335 L202.527199,106.043825 L270,54.7360366 L53.1703911,33.1692308 L53.1703911,33.1692308 Z" id="Shape" fill="#CC2301" sketch:type="MSShapeGroup"></path>
+            <path d="M120.860544,61.8153846 C92.9303566,61.8153846 72.7793296,81.3482278 72.7793296,108.647964 C72.7793296,136.147391 91.5925728,154.161538 121.80858,154.161538 C139.110232,154.161538 156.211744,147.713651 164.575527,133.86672 L142.723302,118.889964 C137.208894,127.045727 130.74645,130.261788 122.761882,130.261788 C113.834545,130.261788 105.66037,124.959491 104.712334,115.285032 L167.050953,115.095852 C167.430168,112.442076 167.430168,109.97748 167.430168,107.518139 C167.430168,80.4023274 150.318122,61.8153846 120.860544,61.8153846 L120.860544,61.8153846 L120.860544,61.8153846 Z M105.209497,96.1153846 C107.112698,88.1990506 113.604727,83.6769231 121.228104,83.6769231 C128.862053,83.6769231 135.163762,88.1990506 137.26257,96.1153846 L105.209497,96.1153846 L105.209497,96.1153846 Z" id="Shape" fill="#FFFFFF" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
This adds the sponsoring css under the `sponsors-detail` namespace. Images in sponsor-level items are removed and replace the old sponsoring categories with the new ones
